### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Sylvan.BuildTools.Resources.Tests/Sylvan.BuildToolsResources.Tests.csproj
+++ b/Sylvan.BuildTools.Resources.Tests/Sylvan.BuildToolsResources.Tests.csproj
@@ -6,18 +6,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-		<PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Build" Version="15.5.180" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.5.180" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" ExcludeAssets="runtime" />
+	<PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build" Version="16.6.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.6.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.6.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.HostModel" Version="3.1.3" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.5.1" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.8.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
    
   </ItemGroup>
 


### PR DESCRIPTION
Hi@MarkPflug, I found an issue in the Sylvan.BuildToolsResources.Tests.csproj:

Packages Microsoft.Build v15.5.180, Microsoft.Build.Tasks.Core v15.5.180, Microsoft.Build.Utilities.Core v15.5.180, NuGet.ProjectModel v5.5.1, xunit v2.4.0 and xunit.runner.visualstudio v2.4.0 transitively introduce 109 dependencies into Sylvan.BuildTools.Resources’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Sylvan-BuildTools-Resources.html)), while Microsoft.Build v16.6.0, Microsoft.Build.Tasks.Core v16.6.0, Microsoft.Build.Utilities.Core v16.6.0, NuGet.ProjectModel v5.8.0, xunit v2.4.1 and xunit.runner.visualstudio v2.4.1 can only introduce 79 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Sylvan-BuildTools-Resources_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose